### PR TITLE
Update reports.js - remove fnchecked

### DIFF
--- a/Jellyfin.Plugin.Reports/Web/reports.js
+++ b/Jellyfin.Plugin.Reports/Web/reports.js
@@ -1,4 +1,4 @@
-define(['jQuery', 'libraryBrowser', 'loading', 'appRouter', 'fnchecked', 'emby-button', 'paper-icon-button-light', 'detailtablecss'], function ($, libraryBrowser, loading, appRouter) {
+define(['jQuery', 'libraryBrowser', 'loading', 'appRouter', 'emby-button', 'paper-icon-button-light', 'detailtablecss'], function ($, libraryBrowser, loading, appRouter) {
     'use strict';
 
     if (!jQuery.mobile || !$.mobile.widgets) {


### PR DESCRIPTION
Remove fnchecked and prevent a failure to open the plugins section on web.

fnchecked.js was removed in web in jellyfin/jellyfin-web#1637